### PR TITLE
Temporarily run the CI on Ubuntu 22.04 rather than latest

### DIFF
--- a/.github/workflows/check-generated-files.yml
+++ b/.github/workflows/check-generated-files.yml
@@ -19,7 +19,7 @@ jobs:
           - 5.0.x
           - 5.1.x
           - 5.2.x
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
           - 5.0.x
           - 5.1.x
           - 5.2.x
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -71,7 +71,7 @@ jobs:
 #          - dune
 #          - make
 #          - make-no-magic
-#    runs-on: ubuntu-latest
+#    runs-on: ubuntu-22.04
 #    container:
 #      image: ghcr.io/thierry-martinez/stdcompat-ocaml-5-beta
 #      credentials:


### PR DESCRIPTION
At the moment, the CI does not work on GitHub's ubuntu-latest runner.
More precisely, the setup-ocaml action fails to install opam.

Until this gets fixed, let's use Ubuntu-22.04 which should work.

This will have to be reverted when things are repaired on Ubuntu latest.