### PR TITLE
Revert "Temporarily run the CI on Ubuntu 22.04 rather than latest"

### DIFF
--- a/.github/workflows/check-generated-files.yml
+++ b/.github/workflows/check-generated-files.yml
@@ -19,7 +19,7 @@ jobs:
           - 5.0.x
           - 5.1.x
           - 5.2.x
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
           - 5.0.x
           - 5.1.x
           - 5.2.x
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -71,7 +71,7 @@ jobs:
 #          - dune
 #          - make
 #          - make-no-magic
-#    runs-on: ubuntu-22.04
+#    runs-on: ubuntu-latest
 #    container:
 #      image: ghcr.io/thierry-martinez/stdcompat-ocaml-5-beta
 #      credentials:


### PR DESCRIPTION
This reverts commit a0076285f4c8709394bd6ed5d32aba608c56cc9b,
as the setup-ocaml GitHub action has now been fixed on the ubuntu-latest
GitHub runners. In terms of PR this reverts PR #58.