### PR TITLE
Do not ignore stdcompat__domain.mli.in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,6 @@ _build/
 /stamp-h1
 *.so
 /stdcompat__stubs.c
-/stdcompat__domain.mli.in
 /stdcompat_tests
 /tools/stdcompatpp.ml
 /tools/stdcompatpp


### PR DESCRIPTION
It was wrong to ignore this file as it is fully part of the
distribution and is not even generated